### PR TITLE
Use height for logo sizing

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -125,7 +125,7 @@ a:hover {
 
 .logo {
   margin: 1rem;
-  width: 200px;
+  height: 50px;
 }
 
 .admonition {
@@ -334,7 +334,7 @@ a:hover {
 @media (max-width: 850px) {
   .logo {
     margin: 1rem;
-    width: 100px;
+    height: 30px;
   }
 
   main {


### PR DESCRIPTION
Closes #13 

Addresses the client's request regarding the CoST and OC4IDS logo sizes. Due to differing aspect ratios, a strict "same size" constraint isn't achievable. 

This PR sets a fixed height for both logos, resulting in the CoST logo appearing slightly larger (wider) than the OC4IDS logo. This ensures the CoST logo is no longer perceived as smaller.